### PR TITLE
Sort getHashrateScoreHistory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+requests.log

--- a/luxor.py
+++ b/luxor.py
@@ -434,7 +434,7 @@ class API:
         """
 
         query = """ query getHashrateScoreHistory($mpn: MiningProfileName!, $uname: String!, $first : Int) {
-                    getHashrateScoreHistory(mpn: $mpn, uname: $uname, first: $first) {
+                    getHashrateScoreHistory(mpn: $mpn, uname: $uname, first: $first, orderBy: DATE_DESC) {
                         nodes {
                             date
                             hashrate
@@ -471,7 +471,7 @@ class API:
     
     def exec(self, method: str, params: Dict[str, Any]) -> requests.Request:
         """
-        Helper function for dinamically calling functions safely.
+        Helper function for dynamically calling functions safely.
 
         Parameters
         ----------


### PR DESCRIPTION
Ordering results for getHashrateScoreHistory is a more sane default.
Also adding .gitignore as the logfile doesn't need committed.