### PR TITLE
Add offset param to get_subaccount api

### DIFF
--- a/luxor.py
+++ b/luxor.py
@@ -159,7 +159,7 @@ class API:
         
         return self.request(query, params)
         
-    def get_subaccounts(self, first: int) -> requests.Request:
+    def get_subaccounts(self, first: int, offset: int = 0) -> requests.Request:
         """
         Returns all subaccounts that belong to the Profile owner of the API Key.
 
@@ -167,10 +167,12 @@ class API:
         ----------
         first : int
             limits the number of data points returned.
+        offset : int
+            skips elements of data points returned.
         """
 
-        query = """query getSubaccounts($first: Int) {users(first: $first) {edges {node {username}}}}"""
-        params = {'first': first}
+        query = """query getSubaccounts($first: Int, $offset: Int) {users(first: $first, offset: $offset) {edges {node {username}}}}"""
+        params = {'first': first, 'offset': offset}
 
         return self.request(query, params)
     


### PR DESCRIPTION
This change allows us to iterate over all the subaccounts to fetch them all. 
This PR is necessary because the maximum number we can use in "first" param is 1000, but there are cases where we have more subaccounts than that, and applying the offset allows me to fetch them all.